### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = "ruby caesar_cipher.rb"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Building-Blocks
 > Initial readme file (pending)
+
+# Demo Links
+[![Run on Repl.it](https://repl.it/badge/github/SlowKingV/building-blocks)](https://repl.it/github/SlowKingV/building-blocks)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@SlwoKing/building-blocks).